### PR TITLE
Use Django 1.9+ location for postgresql backend

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ PostgreSQL engine for Django that supports "ON DELETE CASCADE" at the database l
 
 This is a temporary workaround until `Django's ticket #21961
 <https://code.djangoproject.com/ticket/21961>`_ is fixed. It has been tested
-with Python 2.7, Django 1.6 and Psycopg2 2.6, but should work with other
+with Python 2.7, Django 1.9 and Psycopg2 2.6, but should work with other
 combinations.
 
 To use it, you just have to:
@@ -14,7 +14,7 @@ To use it, you just have to:
 
         pip install django-postgres-delete-cascade
 
-#. Replace the ``django.db.backends.postgresql_psycopg2`` engine with
+#. Replace the ``django.db.backends.postgresql`` engine with
    ``django_postgres_delete_cascade``. For example:
 
     .. code-block:: python

--- a/django_postgres_delete_cascade/base.py
+++ b/django_postgres_delete_cascade/base.py
@@ -14,7 +14,7 @@
 #
 ##############################################################################
 
-from django.db.backends.postgresql_psycopg2.base import \
+from django.db.backends.postgresql.base import \
     DatabaseWrapper as PostgresDatabaseWrapper
 
 from django_postgres_delete_cascade.schema import DatabaseSchemaEditor

--- a/django_postgres_delete_cascade/schema.py
+++ b/django_postgres_delete_cascade/schema.py
@@ -14,7 +14,7 @@
 #
 ##############################################################################
 
-from django.db.backends.postgresql_psycopg2.schema import DatabaseSchemaEditor
+from django.db.backends.postgresql.schema import DatabaseSchemaEditor
 
 
 class DatabaseSchemaEditor(DatabaseSchemaEditor):


### PR DESCRIPTION
This was renamed in [Django Ticket #25175](https://code.djangoproject.com/ticket/25175) and there's an ongoing discussion about removing the old name.

I haven't tested this, hopefully you can.